### PR TITLE
Add option to fine tune non-somatic classif + fix bug

### DIFF
--- a/bc_qualityMetrics_pipeline.m
+++ b/bc_qualityMetrics_pipeline.m
@@ -24,7 +24,7 @@ gain_to_uV = 0.195; % use this if you are not using spikeGLX or openEphys to rec
     % empty(e.g. ephysMetaDir = '')
 
 %% check MATLAB version 
-if exist('isMATLABReleaseOlderThan', 'file') == 0 %% function introduced in MATLAB 2020b.
+if exist('isMATLABReleaseOlderThan', 'file') == 0 % function introduced in MATLAB 2020b.
     oldMATLAB = true;
 else
     oldMATLAB = isMATLABReleaseOlderThan("R2019a");
@@ -68,6 +68,9 @@ bc_loadMetricsForGUI;
 % n : go to next noise unit
 % up/down arrow: toggle between time chunks in the raw data
 % u: brings up a input dialog to enter the unit you want to go to
+
+% currently this GUI works best with a screen in portrait mode - we are
+% working to get it to handle screens in landscape mode better. 
 unitQualityGuiHandle = bc_unitQualityGUI(memMapData, ephysData, qMetric, forGUI, rawWaveforms, ...
     param, probeLocation, unitType, loadRawTraces);
 

--- a/qualityMetrics/bc_checkParameterFields.m
+++ b/qualityMetrics/bc_checkParameterFields.m
@@ -1,12 +1,18 @@
 function param_complete = bc_checkParameterFields(param)
 % JF, Check input structure has all necessary fields + add them with
-% defualt values if not. This is to ensure backcompatibility when any new
+% default values if not. This is to ensure backcompatibility when any new
 % paramaters are introduced. By default, any parameters not already present
 % will be set so that the quality metrics are calculated in the same way as
-% they were before these new parameters were introduced.
+% they were before these new parameters were introduced. (i.e. this does
+% not change anything for the user!).
 % ------
 % Inputs
 % ------
+% - param 
+% ------
+% Outputs
+% ------
+% - param_complete 
 
 
 
@@ -30,6 +36,12 @@ defaultValues.unitType_for_phy = 0;
 
 % separate good from mua in non-somatic
 defaultValues.splitGoodAndMua_NonSomatic = 0;
+
+% waveforms: first peak (before trough) to second peak (after trough) ratio
+defaultValues.firstPeakRatio = 0; % if units have an initial peak before the trough,
+    % it must be at least firstPeakRatio times larger than the peak after
+    % the trough to qualify as a non-somatic unit. 0 means this value is
+    % not used.
 
 %% Check for missing fields and add them with default value
 [param_complete, missingFields] = bc_addMissingFieldsWithDefault(param, defaultValues);

--- a/qualityMetrics/bc_getQualityUnitType.m
+++ b/qualityMetrics/bc_getQualityUnitType.m
@@ -47,22 +47,22 @@ unitType(qMetric.nPeaks > param.maxNPeaks | qMetric.nTroughs > param.maxNTroughs
     qMetric.waveformDuration_peakTrough > param.maxWvDuration | qMetric.waveformBaselineFlatness > param.maxWvBaselineFraction) = 0; % NOISE
 
 % Classify mua units
-unitType((qMetric.percentageSpikesMissing_gaussian > param.maxPercSpikesMissing | qMetric.nSpikes < param.minNumSpikes & ...
-    qMetric.fractionRPVs_estimatedTauR > param.maxRPVviolations | ...
-    qMetric.presenceRatio < param.minPresenceRatio) & isnan(unitType)) = 2; % MUA
+unitType((qMetric.percentageSpikesMissing_gaussian > param.maxPercSpikesMissing | qMetric.nSpikes < param.minNumSpikes | ...
+    qMetric.fractionRPVs_estimatedTauR > param.maxRPVviolations | qMetric.presenceRatio < param.minPresenceRatio) & ...
+    isnan(unitType)) = 2; % MUA
 
 if param.computeDistanceMetrics && ~isnan(param.isoDmin)
-    unitType((qMetric.isoD < param.isoDmin | ...
-        qMetric.Lratio > param.lratioMax) & isnan(unitType)) = 2; 
+    unitType((qMetric.isoD < param.isoDmin | qMetric.Lratio > param.lratioMax) & ...
+        isnan(unitType)) = 2; % MUA
 end
 
 if param.extractRaw
-  unitType((qMetric.rawAmplitude < param.minAmplitude | qMetric.signalToNoiseRatio < param.minSNR) &...
-      isnan(unitType)) = 2; 
+  unitType((qMetric.rawAmplitude < param.minAmplitude | qMetric.signalToNoiseRatio < param.minSNR) & ...
+      isnan(unitType)) = 2; % MUA
 end
 
 if param.computeDrift
-     unitType(qMetric.maxDriftEstimate > param.maxDrift & isnan(unitType)) = 2; 
+     unitType(qMetric.maxDriftEstimate > param.maxDrift & isnan(unitType)) = 2; % MUA
 end
 
 % Classify good units

--- a/qualityMetrics/bc_qualityParamValues.m
+++ b/qualityMetrics/bc_qualityParamValues.m
@@ -98,6 +98,8 @@ param.waveformBaselineWindowStop = 30; % in samples
 param.minThreshDetectPeaksTroughs = 0.2; % this is multiplied by the max value 
     % in a units waveform to give the minimum prominence to detect peaks using
     % matlab's findpeaks function.
+param.firstPeakRatio = 1.1; % if units have an initial peak before the trough,
+    % it must be at least firstPeakRatio times larger than the peak after the trough to qualify as a non-somatic unit. 
 
 % recording parameters
 param.ephys_sample_rate = 30000; % samples per second

--- a/qualityMetrics/bc_runAllQualityMetrics.asv
+++ b/qualityMetrics/bc_runAllQualityMetrics.asv
@@ -1,0 +1,202 @@
+function [qMetric, unitType] = bc_runAllQualityMetrics(param, spikeTimes_samples, spikeTemplates, ...
+    templateWaveforms, templateAmplitudes, pcFeatures, pcFeatureIdx, channelPositions, savePath)
+% JF
+% ------
+% Inputs
+% ------
+% param: parameter structure. See bc_qualityParamValues for all fields
+%   anf information about them.
+%
+% spikeTimes_samples: nSpikes × 1 uint64 vector giving each spike time in samples (*not* seconds)
+%
+% spikeTemplates: nSpikes × 1 uint32 vector giving the identity of each
+%   spike's matched template
+%
+% templateWaveforms: nTemplates × nTimePoints × nChannels single matrix of
+%   template waveforms for each template and channel
+%
+% templateAmplitudes: nSpikes × 1 double vector of the amplitude scaling factor
+%   that was applied to the template when extracting that spike
+%
+% pcFeatures: nSpikes × nFeaturesPerChannel × nPCFeatures  single
+%   matrix giving the PC values for each spike
+%
+% pcFeatureIdx: nTemplates × nPCFeatures uint32  matrix specifying which
+%   channels contribute to each entry in dim 3 of the pc_features matrix
+%
+% channelPositions: nChannels x 2 double matrix corresponding to the x and
+%   z locations of each channel on the probe, in um
+%
+% savePath: sting defining the path where to save bombcell's output
+%
+%------
+% Outputs
+% ------
+% qMetric: structure with fields:
+%   percentageSpikesMissing : a gaussian is fit to the spike amplitudes with a
+%       'cutoff' parameter below which there are no spikes to estimate the
+%       percentage of spikes below the spike-sorting detection threshold - will
+%       slightly underestimate in the case of 'bursty' cells with burst
+%       adaptation (eg see Fig 5B of Harris/Buzsaki 2000 DOI: 10.1152/jn.2000.84.1.401)
+%   fractionRefractoryPeriodViolations: percentage of false positives, ie spikes within the refractory period
+%       defined by param.tauR of another spike. This also excludes
+%       duplicated spikes that occur within param.tauC of another spike.
+%   useTheseTimes : param.computeTimeChunks, this defines the time chunks
+%       (deivding the recording in time of chunks of param.deltaTimeChunk size)
+%       where the percentage of spike missing and percentage of false positives
+%       is below param.maxPercSpikesMissing and param.maxRPVviolations
+%   nSpikes : number of spikes for each unit
+%   nPeaks : number of detected peaks in each units template waveform
+%   nTroughs : number of detected troughs in each units template waveform
+%   isSomatic : a unit is defined as Somatic of its trough precedes its main
+%       peak (see Deligkaris/Frey DOI: 10.3389/fnins.2016.00421)
+%   rawAmplitude : amplitude in uV of the units mean raw waveform at its peak
+%       channel. The peak channel is defined by the template waveform.
+%   spatialDecay : gets the minumum amplitude for each unit 5 channels from
+%       the peak channel and calculates the slope of this decrease in amplitude.
+%   isoD : isolation distance, a measure of how well a units spikes are seperate from
+%       other nearby units spikes
+%   Lratio : l-ratio, a similar measure to isolation distance. see
+%       Schmitzer-Torbert/Redish 2005  DOI: 10.1016/j.neuroscience.2004.09.066
+%       for a comparison of l-ratio/isolation distance
+%   silhouetteScore : another measure similar ti isolation distance and
+%       l-ratio. See Rousseeuw 1987 DOI: 10.1016/0377-0427(87)90125-7)
+%
+% unitType: nUnits x 1 vector indicating whether each unit met the
+%   threshold criterion to be classified as a single unit (1), noise
+%   (0) or multi-unit (2)
+
+%% prepare for quality metrics computations
+% initialize structures
+qMetric = struct;
+forGUI = struct;
+
+% check parameter values
+param = bc_checkParameterFields(param);
+
+% get unit max channels
+maxChannels = bc_getWaveformMaxChannel(templateWaveforms);
+
+% extract and save or load in raw waveforms
+[rawWaveformsFull, rawWaveformsPeakChan, signalToNoiseRatio] = bc_extractRawWaveformsFast(param, ...
+    spikeTimes_samples, spikeTemplates, param.reextractRaw, savePath, param.verbose); % takes ~10' for
+% an average dataset, the first time it is run, <1min after that
+
+% remove any duplicate spikes
+[uniqueTemplates, ~, spikeTimes_samples, spikeTemplates, templateAmplitudes, ...
+    pcFeatures, rawWaveformsFull, rawWaveformsPeakChan, signalToNoiseRatio, ...
+    qMetric.maxChannels] = ...
+    bc_removeDuplicateSpikes(spikeTimes_samples, spikeTemplates, templateAmplitudes, ...
+    pcFeatures, rawWaveformsFull, rawWaveformsPeakChan, signalToNoiseRatio, ...
+    maxChannels, param.removeDuplicateSpikes, param.duplicateSpikeWindow_s, ...
+    param.ephys_sample_rate, param.saveSpikes_withoutDuplicates, savePath, param.recomputeDuplicateSpikes);
+
+% divide recording into time chunks
+spikeTimes_seconds = spikeTimes_samples ./ param.ephys_sample_rate; %convert to seconds after using sample indices to extract raw waveforms
+if param.computeTimeChunks
+    timeChunks = [min(spikeTimes_seconds):param.deltaTimeChunk:max(spikeTimes_seconds), max(spikeTimes_seconds)];
+else
+    timeChunks = [min(spikeTimes_seconds), max(spikeTimes_seconds)];
+end
+
+%% loop through units and get quality metrics
+fprintf('\n Extracting quality metrics from %s ... \n', param.rawFile)
+
+for iUnit = 97:99%51:100%size(uniqueTemplates, 1)
+
+    clearvars thisUnit theseSpikeTimes theseAmplis theseSpikeTemplates
+    % get this unit's attributes
+    thisUnit = uniqueTemplates(iUnit);
+    qMetric.phy_clusterID(iUnit) = thisUnit - 1; % this is the cluster ID as it appears in phy
+    qMetric.clusterID(iUnit) = thisUnit; % this is the cluster ID as it appears in phy, 1-indexed (adding 1)
+
+    theseSpikeTimes = spikeTimes_seconds(spikeTemplates == thisUnit);
+    theseAmplis = templateAmplitudes(spikeTemplates == thisUnit);
+
+    %% percentage spikes missing (false negatives)
+    [percentageSpikesMissing_gaussian, percentageSpikesMissing_symmetric, ksTest_pValue, ~, ~, ~] = ...
+        bc_percSpikesMissing(theseAmplis, theseSpikeTimes, timeChunks, param.plotDetails);
+
+    %% fraction contamination (false positives)
+    tauR_window = param.tauR_valuesMin:param.tauR_valuesStep:param.tauR_valuesMax;
+    [fractionRPVs, ~, ~] = bc_fractionRPviolations(theseSpikeTimes, theseAmplis, ...
+        tauR_window, param.tauC, ...
+        timeChunks, param.plotDetails, NaN);
+
+    %% define timechunks to keep: keep times with low percentage spikes missing and low fraction contamination
+    [theseSpikeTimes, theseAmplis, theseSpikeTemplates, qMetric.useTheseTimesStart(iUnit), qMetric.useTheseTimesStop(iUnit), ...
+        qMetric.RPV_tauR_estimate(iUnit)] = bc_defineTimechunksToKeep( ...
+        percentageSpikesMissing_gaussian, fractionRPVs, param.maxPercSpikesMissing, ...
+        param.maxRPVviolations, theseAmplis, theseSpikeTimes, spikeTemplates, timeChunks); %QQ add kstest thing, symmetric ect
+
+    %% re-compute percentage spikes missing and fraction contamination on timechunks
+    thisUnits_timesToUse = [qMetric.useTheseTimesStart(iUnit), qMetric.useTheseTimesStop(iUnit)];
+
+    [qMetric.percentageSpikesMissing_gaussian(iUnit), qMetric.percentageSpikesMissing_symmetric(iUnit), ...
+        qMetric.ksTest_pValue(iUnit), forGUI.ampliBinCenters{iUnit}, forGUI.ampliBinCounts{iUnit}, ...
+        forGUI.ampliGaussianFit{iUnit}] = bc_percSpikesMissing(theseAmplis, theseSpikeTimes, ...
+        thisUnits_timesToUse, param.plotDetails);
+
+    [qMetric.fractionRPVs(iUnit, :), ~, ~] = bc_fractionRPviolations(theseSpikeTimes, theseAmplis, ...
+        tauR_window, param.tauC, thisUnits_timesToUse, param.plotDetails, qMetric.RPV_tauR_estimate(iUnit));
+
+    %% presence ratio (potential false negatives)
+    [qMetric.presenceRatio(iUnit)] = bc_presenceRatio(theseSpikeTimes, theseAmplis, param.presenceRatioBinSize, ...
+        qMetric.useTheseTimesStart(iUnit), qMetric.useTheseTimesStop(iUnit), param.plotDetails);
+
+    %% maximum cumulative drift estimate
+    [qMetric.maxDriftEstimate(iUnit), qMetric.cumDriftEstimate(iUnit)] = bc_maxDriftEstimate(pcFeatures, pcFeatureIdx, theseSpikeTemplates, ...
+        theseSpikeTimes, channelPositions(:, 2), thisUnit, param.driftBinSize, param.computeDrift, param.plotDetails);
+
+    %% number spikes
+    qMetric.nSpikes(iUnit) = bc_numberSpikes(theseSpikeTimes);
+
+    %% waveform
+    param.plotDetails = 1;
+    waveformBaselineWindow = [param.waveformBaselineWindowStart, param.waveformBaselineWindowStop];
+    [qMetric.nPeaks(iUnit), qMetric.nTroughs(iUnit), qMetric.isSomatic(iUnit), forGUI.peakLocs{iUnit}, ...
+        forGUI.troughLocs{iUnit}, qMetric.waveformDuration_peakTrough(iUnit), ...
+        forGUI.spatialDecayPoints(iUnit, :), qMetric.spatialDecaySlope(iUnit), qMetric.waveformBaselineFlatness(iUnit), ... .
+        forGUI.tempWv(iUnit, :)] = bc_waveformShape(templateWaveforms, thisUnit, qMetric.maxChannels(thisUnit), ...
+        param.ephys_sample_rate, channelPositions, param.maxWvBaselineFraction, waveformBaselineWindow, ...
+        param.minThreshDetectPeaksTroughs, param.plotDetails); %do we need tempWv ?
+    param.plotDetails = 0;
+
+    %% amplitude
+    if param.extractRaw
+        qMetric.rawAmplitude(iUnit) = bc_getRawAmplitude(rawWaveformsFull(iUnit, rawWaveformsPeakChan(iUnit), :), ...
+            param.ephysMetaFile, param.probeType, param.gain_to_uV);
+    else
+        qMetric.rawAmplitude(iUnit) = NaN;
+        qMetric.signalToNoiseRatio(iUnit) = NaN;
+    end
+
+    %% distance metrics
+    if param.computeDistanceMetrics
+        [qMetric.isoD(iUnit), qMetric.Lratio(iUnit), qMetric.silhouetteScore(iUnit), ...
+            forGUI.d2_mahal{iUnit}, forGUI.mahalobnis_Xplot{iUnit}, forGUI.mahalobnis_Yplot{iUnit}] = bc_getDistanceMetrics(pcFeatures, ...
+            pcFeatureIdx, thisUnit, sum(spikeTemplates == thisUnit), spikeTemplates == thisUnit, theseSpikeTemplates, ...
+            param.nChannelsIsoDist, param.plotDetails); %QQ
+    end
+
+    %% display progress
+    if ((mod(iUnit, 50) == 0) || iUnit == length(uniqueTemplates)) && param.verbose
+        fprintf(['\n   Finished ', num2str(iUnit), ' / ', num2str(length(uniqueTemplates)), ' units.']);
+    end
+
+end
+
+%% get unit types and save data
+qMetric.maxChannels = qMetric.maxChannels(uniqueTemplates)';
+if param.extractRaw
+    qMetric.signalToNoiseRatio = signalToNoiseRatio';
+end
+
+fprintf('\n Finished extracting quality metrics from %s', param.rawFile)
+
+qMetric = bc_saveQMetrics(param, qMetric, forGUI, savePath);
+fprintf('\n Saved quality metrics from %s to %s \n', param.rawFile, savePath)
+
+unitType = bc_getQualityUnitType(param, qMetric, savePath);
+bc_plotGlobalQualityMetric(qMetric, param, unitType, uniqueTemplates, forGUI.tempWv);
+end

--- a/qualityMetrics/bc_runAllQualityMetrics.m
+++ b/qualityMetrics/bc_runAllQualityMetrics.m
@@ -152,6 +152,7 @@ for iUnit = 1:size(uniqueTemplates, 1)
     qMetric.nSpikes(iUnit) = bc_numberSpikes(theseSpikeTimes);
 
     %% waveform
+    param.plotDetails = 1;
     waveformBaselineWindow = [param.waveformBaselineWindowStart, param.waveformBaselineWindowStop];
     [qMetric.nPeaks(iUnit), qMetric.nTroughs(iUnit), qMetric.isSomatic(iUnit), forGUI.peakLocs{iUnit}, ...
         forGUI.troughLocs{iUnit}, qMetric.waveformDuration_peakTrough(iUnit), ...
@@ -159,6 +160,7 @@ for iUnit = 1:size(uniqueTemplates, 1)
         forGUI.tempWv(iUnit, :)] = bc_waveformShape(templateWaveforms, thisUnit, qMetric.maxChannels(thisUnit), ...
         param.ephys_sample_rate, channelPositions, param.maxWvBaselineFraction, waveformBaselineWindow, ...
         param.minThreshDetectPeaksTroughs, param.plotDetails); %do we need tempWv ?
+    param.plotDetails = 0;
 
     %% amplitude
     if param.extractRaw

--- a/qualityMetrics/bc_runAllQualityMetrics.m
+++ b/qualityMetrics/bc_runAllQualityMetrics.m
@@ -152,7 +152,6 @@ for iUnit = 1:size(uniqueTemplates, 1)
     qMetric.nSpikes(iUnit) = bc_numberSpikes(theseSpikeTimes);
 
     %% waveform
-    param.plotDetails = 1;
     waveformBaselineWindow = [param.waveformBaselineWindowStart, param.waveformBaselineWindowStop];
     [qMetric.nPeaks(iUnit), qMetric.nTroughs(iUnit), qMetric.isSomatic(iUnit), forGUI.peakLocs{iUnit}, ...
         forGUI.troughLocs{iUnit}, qMetric.waveformDuration_peakTrough(iUnit), ...
@@ -160,7 +159,6 @@ for iUnit = 1:size(uniqueTemplates, 1)
         forGUI.tempWv(iUnit, :)] = bc_waveformShape(templateWaveforms, thisUnit, qMetric.maxChannels(thisUnit), ...
         param.ephys_sample_rate, channelPositions, param.maxWvBaselineFraction, waveformBaselineWindow, ...
         param.minThreshDetectPeaksTroughs, param.plotDetails); %do we need tempWv ?
-    param.plotDetails = 0;
 
     %% amplitude
     if param.extractRaw

--- a/qualityMetrics/bc_runAllQualityMetrics.m
+++ b/qualityMetrics/bc_runAllQualityMetrics.m
@@ -158,7 +158,7 @@ for iUnit = 1:size(uniqueTemplates, 1)
         forGUI.spatialDecayPoints(iUnit, :), qMetric.spatialDecaySlope(iUnit), qMetric.waveformBaselineFlatness(iUnit), ... .
         forGUI.tempWv(iUnit, :)] = bc_waveformShape(templateWaveforms, thisUnit, qMetric.maxChannels(thisUnit), ...
         param.ephys_sample_rate, channelPositions, param.maxWvBaselineFraction, waveformBaselineWindow, ...
-        param.minThreshDetectPeaksTroughs, param.plotDetails); %do we need tempWv ?
+        param.minThreshDetectPeaksTroughs, param.firstPeakRatio, param.plotDetails); %do we need tempWv ?
 
     %% amplitude
     if param.extractRaw

--- a/qualityMetrics/bc_waveformShape.asv
+++ b/qualityMetrics/bc_waveformShape.asv
@@ -99,21 +99,21 @@ peakLoc = peakLocs(PKS == max(PKS)); %QQ could change to better:
     % by looking for location where the data is most tightly distributed
     
     % check if this is the correct peak 
-maxPK = max(PKS);
-if peakLoc < troughLoc
-    if ~isempty(find(peakLocs>troughLocs))
-        possible_realPeak = PKS(find(peakLocs>troughLocs));
-    else
-        [possible_realPeak, possible_peakLoc] = max(thisWaveform(troughLoc:end));
+    maxPK = max(PKS);
+    if peakLoc < troughLoc
+        if ~isempty(find(peakLocs>troughLocs))
+            possible_realPeak = PKS(find(peakLocs>troughLocs));
+        else
+            [possible_realPeak, possible_peakLoc] = max(thisWaveform(troughLoc:end));
+        end
+        if maxPK < (possible_realPeak * 1.1) %QQ hardcoded for now 
+             if isempty(find(peakLocs>troughLocs))
+                PKS = [PKS, possible_realPeak];
+                peakLocs = [peakLocs, possible_peakLoc + troughLoc - 1];
+             end
+             peakLoc = peakLocs(PKS == possible_realPeak);
+        end
     end
-    if maxPK < (possible_realPeak * 1.1) %QQ hardcoded for now 
-         if isempty(find(peakLocs>troughLocs))
-            PKS = [PKS, possible_realPeak];
-            peakLocs = [peakLocs, possible_peakLoc + troughLoc - 1];
-         end
-         peakLoc = peakLocs(PKS == possible_realPeak);
-    end
-end
 if numel(peakLoc) > 1
     peakLoc = peakLoc(1);
 end

--- a/qualityMetrics/bc_waveformShape.asv
+++ b/qualityMetrics/bc_waveformShape.asv
@@ -1,8 +1,7 @@
 function [nPeaks, nTroughs, isSomatic, peakLocs, troughLocs, waveformDuration_peakTrough, ...
-    spatialDecayPoints, spatialDecaySlope, ...
-    waveformBaseline, thisWaveform] = bc_waveformShape(templateWaveforms, ...
+    spatialDecayPoints, spatialDecaySlope, waveformBaseline, thisWaveform] = bc_waveformShape(templateWaveforms, ...
     thisUnit, maxChannel, ephys_sample_rate, channelPositions, baselineThresh, ...
-    waveformBaselineWindow, minThreshDetectPeaksTroughs, plotThis)
+    waveformBaselineWindow, minThreshDetectPeaksTroughs, firstPeakRatio, plotThis)
 % JF
 % Get the number of troughs and peaks for each waveform,
 % determine whether waveform is likely axonal/dendritic (biggest peak before
@@ -27,6 +26,8 @@ function [nPeaks, nTroughs, isSomatic, peakLocs, troughLocs, waveformDuration_pe
 %   units are classified as noise, only needed if plotThis is set to true
 % waveformBaselineWindow: QQ describe
 % minThreshDetectPeaksTroughs:  QQ describe
+% firstPeakRatio: 1 x 1 double. if units have an initial peak before the trough,
+%   it must be at least firstPeakRatio times larger than the peak after the trough to qualify as a non-somatic unit. 
 % plotThis: boolean, whether to plot waveform and detected peaks or not
 % ------
 % Outputs
@@ -52,14 +53,14 @@ function [nPeaks, nTroughs, isSomatic, peakLocs, troughLocs, waveformDuration_pe
 
 % (find peaks and troughs using MATLAB's built-in function)
 thisWaveform = templateWaveforms(thisUnit, :, maxChannel);
-minProminence = minThreshDetectPeaksTroughs * max(abs(squeeze(thisWaveform))); % minimum threshold to detcet peaks/troughs
+minProminence = minThreshDetectPeaksTroughs * max(abs(squeeze(thisWaveform))); % minimum threshold to detect peaks/troughs
 
-[PKS, peakLocs, ~] = findpeaks(squeeze(thisWaveform), 'MinPeakProminence', minProminence); % get peaks
+[PKS, peakLocs] = findpeaks(squeeze(thisWaveform), 'MinPeakProminence', minProminence); % get peaks
 
 [TRS, troughLocs] = findpeaks(squeeze(thisWaveform)*-1, 'MinPeakProminence', minProminence); % get troughs
 
-% (check and sanitize the trough output) 
-    % if there is no detected trough, just take minimum value as trough
+% (check and sanitize the trough output)
+% if there is no detected trough, just take minimum value as trough
 if isempty(TRS) %
     TRS = min(squeeze(thisWaveform));
     nTroughs = numel(TRS);
@@ -72,9 +73,9 @@ else
     nTroughs = numel(TRS);
 end
 
-% (check and sanitize the peak output) 
-    % if there is no detected peak, just take maximum value as peak
-if isempty(PKS) 
+% (check and sanitize the peak output)
+% if there is no detected peak, just take maximum value as peak
+if isempty(PKS)
     PKS = max(squeeze(thisWaveform));
     nPeaks = numel(PKS);
     if numel(PKS) > 1 % if more than one peak, take the first (usually the correct one) %QQ should change to better:
@@ -85,70 +86,70 @@ if isempty(PKS)
 else
     nPeaks = numel(PKS);
 end
-    
 
-% (get the peak and trough locations) 
+
+% (get the peak and trough locations)
 troughLoc = troughLocs(TRS == max(TRS)); %QQ could change to better:
-    % by looking for location where the data is most tightly distributed
+% by looking for location where the data is most tightly distributed
 if numel(troughLoc) > 1
     troughLoc = troughLoc(1);
 end
 
 
 peakLoc = peakLocs(PKS == max(PKS)); %QQ could change to better:
-    % by looking for location where the data is most tightly distributed
-    
-    % check if this is the correct peak 
-    maxPK = max(PKS);
-    if peakLoc < troughLoc
-        if ~isempty(find(peakLocs>troughLocs))
-            possible_realPeak = PKS(find(peakLocs>troughLocs));
-        else
-            [possible_realPeak, possible_peakLoc] = max(thisWaveform(troughLoc:end));
-        end
-        if maxPK < (possible_realPeak * 1.1) %QQ hardcoded for now 
-             if isempty(find(peakLocs>troughLocs))
-                PKS = [PKS, possible_realPeak];
-                peakLocs = [peakLocs, possible_peakLoc + troughLoc - 1];
-             end
-             peakLoc = peakLocs(PKS == possible_realPeak);
-        end
+% by looking for location where the data is most tightly distributed
+
+% check if this is the correct peak
+maxPK = max(PKS);
+if peakLoc < troughLoc
+    if sum(any(peakLocs) > troughLocs) > 0
+        possible_realPeak = PKS(peakLocs > troughLocs);
+    else
+        [possible_realPeak, possible_peakLoc] = max(thisWaveform(troughLoc:end));
     end
+    if maxPK < (possible_realPeak * firstPeakRatio) 
+        if sum(any(peakLocs) > troughLocs) == 0
+            PKS = [PKS, possible_realPeak];
+            peakLocs = [peakLocs, possible_peakLoc + troughLoc - 1];
+        end
+        peakLoc = peakLocs(PKS == possible_realPeak);
+    end
+end
 if numel(peakLoc) > 1
     peakLoc = peakLoc(1);
 end
 
-% (assess whether waveform comes from a non-somatic unit or not) 
-    % if maximum peak is after trough and maximum absolute peak value is smaller than trough
-if peakLoc > troughLoc && max(TRS) > max(PKS) 
+% (assess whether waveform comes from a non-somatic unit or not)
+% if maximum peak is after trough and maximum absolute peak value is smaller than trough
+if peakLoc > troughLoc && max(TRS) > max(PKS)
     isSomatic = 1; % is a somatic spike
 else
     isSomatic = 0;
 end
 
 % (get waveform peak to trough duration)
-    % first assess which peak loc to use
+% first assess which peak loc to use
 max_waveform_abs_value = max(abs(thisWaveform));
 max_waveform_location = abs(thisWaveform) == max_waveform_abs_value;
 max_waveform_value = thisWaveform(max_waveform_location);
 if max_waveform_value(end) > 0
     peakLoc_forDuration = peakLoc;
-    [~,troughLoc_forDuration] = min(thisWaveform(peakLoc_forDuration:end)); % to calculate waveform duration
-    troughLoc_forDuration = troughLoc_forDuration + peakLoc_forDuration -1;
+    [~, troughLoc_forDuration] = min(thisWaveform(peakLoc_forDuration:end)); % to calculate waveform duration
+    troughLoc_forDuration = troughLoc_forDuration + peakLoc_forDuration - 1;
 else
     troughLoc_forDuration = troughLoc;
-    [~,peakLoc_forDuration] = max(thisWaveform(troughLoc_forDuration:end)); % to calculate waveform duration
-    peakLoc_forDuration = peakLoc_forDuration + troughLoc_forDuration -1;
+    [~, peakLoc_forDuration] = max(thisWaveform(troughLoc_forDuration:end)); % to calculate waveform duration
+    peakLoc_forDuration = peakLoc_forDuration + troughLoc_forDuration - 1;
 end
 
-    % waveform duration in microseconds 
+% waveform duration in microseconds
 if ~isempty(troughLoc) && ~isempty(peakLoc_forDuration)
     waveformDuration_peakTrough = 1e6 * abs(troughLoc_forDuration-peakLoc_forDuration) / ephys_sample_rate; %in us
 else
     waveformDuration_peakTrough = NaN;
 end
 
-% (get waveform spatial decay accross channels) 
+% (get waveform spatial decay accross channels)
 channels_withSameX = find(channelPositions(:, 1) <= channelPositions(maxChannel, 1)+33 & ...
     channelPositions(:, 1) >= channelPositions(maxChannel, 1)-33); % for 4 shank probes
 if numel(channels_withSameX) >= 5
@@ -179,15 +180,15 @@ else
 
 end
 
-% (get waveform baseline fraction) 
+% (get waveform baseline fraction)
 if ~isnan(waveformBaselineWindow(1))
     waveformBaseline = max(abs(thisWaveform(waveformBaselineWindow(1): ...
         waveformBaselineWindow(2)))) / max(abs(thisWaveform));
 else
-    waveformBaseline=NaN;
+    waveformBaseline = NaN;
 end
 
-% (plot waveform) 
+% (plot waveform)
 if plotThis
 
     colorMtx = bc_colors(8);
@@ -218,7 +219,7 @@ if plotThis
     max_value = max(max(abs(squeeze(templateWaveforms(thisUnit, :, chansToPlot))))) * 5;
     for iChanToPlot = 1:min(20, size(chansToPlot, 1))
 
-        if maxChan == chansToPlot(iChanToPlot)% max channel
+        if maxChan == chansToPlot(iChanToPlot) % max channel
             % plot waveform line
             p1 = plot((wvTime + (channelPositions(chansToPlot(iChanToPlot), 1) - 11) / 10), ...
                 -squeeze(templateWaveforms(thisUnit, :, chansToPlot(iChanToPlot)))'+ ...
@@ -246,7 +247,7 @@ if plotThis
                 [-baselineThresh * -max(abs(thisWaveform))' + ...
                 (channelPositions(chansToPlot(iChanToPlot), 2) ./ 100 * max_value), -baselineThresh * -max(abs(thisWaveform))' + ...
                 (channelPositions(chansToPlot(iChanToPlot), 2) ./ 100 * max_value)], 'Color', colorMtx(4, :, :));
-            
+
             % plot waveform duration
             pT_locs = [troughLoc_forDuration, peakLoc_forDuration];
             dur = plot([(wvTime(min(pT_locs)) ...


### PR DESCRIPTION
- Added an option to fine-tune the non-somatic classification. Now, if a unit has a detected peak only before the trough, it is no longer automatically classified as non-somatic. The peak needs to be `param.firstPeakRatio` times larger than any value after the waveform's trough. Thanks @[LaurenzMuessig](https://github.com/LaurenzMuessig) .

- Fixed a bug in classifying MUA unit. Thanks @[JRegg66](https://github.com/JRegg66).