### PR TITLE
Dat file support

### DIFF
--- a/pyBombCell/bombcell/extract_raw_waveforms.py
+++ b/pyBombCell/bombcell/extract_raw_waveforms.py
@@ -513,6 +513,9 @@ def manage_data_compression(ephys_raw_dir):
             if pre_ext != ".lf":
                 decompressed_data = file
 
+        if ext == ".dat":
+            decompressed_data = file
+
         if ext == ".cbin":
             compressed_data = file
 


### PR DESCRIPTION
BombCell's function extract_raw_waveforms() does so from the file pointed to by param["raw_data_file"]. On the OmniPlex platform, wideband data originally recorded in the PL2 format is converted to BIN format via a utility called PL2BIN. The data contained within the resulting BIN file is completely raw, having undergone no filtering, CAR, CMR, or whitening.

Pointing param["raw_data_file"] at Plexon's BIN file is problematic because it is a bad idea to try to extract waveforms from unfiltered data. An alternative is to use temp_wh.dat, a file generated by Kilosort in its output folder. My initial attempt to do so failed because manage_data_compression() was set up only to work in a limited set of cases. I have added a new case for when the extension is ".dat".