### PR TITLE
Added cachecache to requirements.txt

### DIFF
--- a/py_bombcell/requirements.txt
+++ b/py_bombcell/requirements.txt
@@ -10,3 +10,4 @@
 	numba>=0.58.1
 	upsetplot
 	mtscomp
+	cachecache


### PR DESCRIPTION
Recent updates to BombCell's codebase appear to rely on a package called "cachecache". I have added this package to requirements.txt so that it gets installed to whatever environment we are using BombCell in.