### PR TITLE
Updated detrending command to prevent break when n_sync_channels=0.

### DIFF
--- a/py_bombcell/bombcell/extract_raw_waveforms.py
+++ b/py_bombcell/bombcell/extract_raw_waveforms.py
@@ -123,9 +123,11 @@ def process_a_unit(
 
         # option to remove a linear in time trends
         if detrendWaveform:
-            detrended = detrend(tmp[:, :-n_sync_channels], axis=0).swapaxes(
-                0, 1
-            )
+            if n_sync_channels > 0:
+                detrended = detrend(tmp[:, :-n_sync_channels], axis=0).swapaxes(0, 1)
+            else:
+                detrended = detrend(tmp[:, :], axis=0).swapaxes(0, 1)
+            
             spike_map[:, :, i] = detrended
         else:
             spike_map[:, :, i] = tmp[:, :-n_sync_channels].swapaxes(0, 1)
@@ -451,7 +453,6 @@ def extract_raw_waveforms(
             )
             for i, cid in tqdm(enumerate(unique_clusters))
         )
-
 
         (raw_waveforms,
          raw_waveforms_full,


### PR DESCRIPTION
Fixes #333 

When n_sync_channels = 0, the command

`detrended = detrend(tmp[:, :-n_sync_channels], axis=0).swapaxes(0, 1)`

reduces to 

`detrended = detrend(tmp[:, :-0], axis=0).swapaxes(0, 1)`

Since tmp[:, :-0] is empty, this results in an error. 

I have fixed this bug by introducing an if/else statement predicated on whether n_sync_channels > 0.