### PR TITLE
Improve pair-wise ISI violations computation efficiency

### DIFF
--- a/py_bombcell/bombcell/quality_metrics.py
+++ b/py_bombcell/bombcell/quality_metrics.py
@@ -711,11 +711,12 @@ def fraction_RP_violations(these_spike_times, these_amplitudes, time_chunks, par
                 isi_violations_sum = 0
 
                 # Count all pair-wise violations
-                for i in range(N):
-                    for j in range(i+1, N):
-                        isi = chunk_spike_times[j] - chunk_spike_times[i]
-                        if isi <= tauR and isi >= tauC:
-                            isi_violations_sum += 1
+                if N > 1:
+                    for i in range(N - 1):
+                        isi_vec = chunk_spike_times[i+1:] - chunk_spike_times[i]
+                        isi_violations_sum += np.sum((isi_vec <= tauR) & (isi_vec >= tauC))
+                else:
+                    isi_violations_sum = 0
 
                 # Calculate fraction using Llobet equation
                 if N > 0:  # Avoid division by zero


### PR DESCRIPTION
Hi @Julie-Fabre !
I would like to suggest a small modification to the code used in the computation of pair-wise ISI violations for the Llobet et al. refractory period violations method in `quality_metrics.py`.

The current implementation is extremely slow, due to the nested for loops, as you can see in the attached screenshot (an exemplar single unit of a recording from our lab is considered).

Firstly, I tried a fully vectorized implementation, but the issue with that solution was the saturation of memory, thus I am now proposing a partially vectorized implementation significantly increasing the computation speed.

Hope this helps! :)

<img width="1315" height="1158" alt="image" src="https://github.com/user-attachments/assets/4cecd157-4af6-4100-9f99-3179c21bbe68" />
