### PR TITLE
Added parameter 'joblib_backend_preference' to provide greater flexibility for how joblib processes multiple units simultaneously

### DIFF
--- a/py_bombcell/bombcell/default_parameters.py
+++ b/py_bombcell/bombcell/default_parameters.py
@@ -43,6 +43,7 @@ def get_default_parameters(
         "saveAsTSV": True,  # save outputs as a .tsv file, useful for using phy after bombcell
         "unit_type_for_phy": True,  # save a unit_type .tsv file for phy
         "ephysKilosortPath": str(kilosort_path),  # path to the KiloSort directory
+        "joblib_backend_preference": "processes", # 'processes' OR 'threads
 
         ## Duplicate spike parameters
         "removeDuplicateSpikes": False,

--- a/py_bombcell/bombcell/extract_raw_waveforms.py
+++ b/py_bombcell/bombcell/extract_raw_waveforms.py
@@ -524,7 +524,8 @@ def extract_raw_waveforms(
                 all_spikes_idxs[i, : len(clus_spike_times[i])] = clus_spike_times[i]
                 all_spikes_idxs[i, len(clus_spike_times[i]) :] = np.nan
 
-        all_waveforms = Parallel(n_jobs=-1, verbose=10, mmap_mode="r", max_nbytes=None)(
+        prefer = param["joblib_backend_preference"]
+        all_waveforms = Parallel(n_jobs=-1, verbose=10, mmap_mode="r", max_nbytes=None, prefer=prefer)(
             delayed(process_a_unit)(
                 raw_data,
                 spike_width,

--- a/py_bombcell/bombcell/extract_raw_waveforms.py
+++ b/py_bombcell/bombcell/extract_raw_waveforms.py
@@ -524,7 +524,11 @@ def extract_raw_waveforms(
                 all_spikes_idxs[i, : len(clus_spike_times[i])] = clus_spike_times[i]
                 all_spikes_idxs[i, len(clus_spike_times[i]) :] = np.nan
 
-        prefer = param["joblib_backend_preference"]
+        try:
+            prefer = param["joblib_backend_preference"]
+        except KeyError:
+            param["joblib_backend_preference"] = "processes"
+            prefer = param["joblib_backend_preference"]
         all_waveforms = Parallel(n_jobs=-1, verbose=10, mmap_mode="r", max_nbytes=None, prefer=prefer)(
             delayed(process_a_unit)(
                 raw_data,


### PR DESCRIPTION
feat: extract_raw_waveforms() uses joblib's 'Parallel' class to speed up the processing of multiple units' worth of data. The default engine that joblib uses - 'loky' - is process-based. Some use-cases work better with another engine, 'threads'. I have introduced a new parameter called 'joblib_backend_preference' with the default value 'processes'. This should produce no change in behavior if left untouched. Should the user wish to use the thread-based engine, they can change this parameter's value to 'threads'.