### PR TITLE
fix: index template_peak_channels by cluster ID, not loop counter

### DIFF
--- a/py_bombcell/bombcell/extract_raw_waveforms.py
+++ b/py_bombcell/bombcell/extract_raw_waveforms.py
@@ -774,7 +774,7 @@ def extract_raw_waveforms(
                 waveform_baseline_noise,
                 raw_waveforms_dir,
                 save_multiple_raw,
-                template_peak_channels[i] if template_peak_channels is not None and i < len(template_peak_channels) else None,
+                template_peak_channels[cid] if template_peak_channels is not None and cid < len(template_peak_channels) else None,
             )
             for i, cid in tqdm(enumerate(unique_clusters))
         )


### PR DESCRIPTION
In the bulk extraction loop, template_peak_channels[i] used the
sequential enumerate counter instead of the cluster ID (cid). When
dead templates create gaps in cluster IDs, this causes each subsequent
unit to read the wrong template's peak channel, writing incorrect
values to the cached .npy files.

This is the extraction-side counterpart of the helper_functions.py fix
(maxChannels[unit_idx] -> maxChannels[this_unit]).
